### PR TITLE
Support deployment to Kubernetes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.bundle
+.git
+.byebug_history
+Dockerfile
+log
+tmp
+public/assets
+vendor/bundle

--- a/.gitignore
+++ b/.gitignore
@@ -16,13 +16,16 @@
 # Ignore Byebug command history file.
 .byebug_history
 
-config/postal.yml
-config/smtp.cert
-config/smtp.key
-config/lets_encrypt.pem
-config/signing.key
-config/fast_server.cert
-config/fast_server.key
+# GoCardless: Vendor our own configuration files that hook into environment
+# variables.
+#
+# config/postal.yml
+# config/smtp.cert        # POSTAL_SMTP_CERT
+# config/smtp.key         # POSTAL_SMTP_KEY
+# config/lets_encrypt.pem # POSTAL_LETS_ENCRYPT_PEM
+# config/signing.key      # POSTAL_SIGNING_KEY
+# config/fast_server.cert # POSTAL_FAST_SERVER_CERT
+# config/fast_server.key  # POSTAL_FAST_SERVER_KEY
 
 public/assets
 vendor/bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ruby:2.5-alpine
+
+MAINTAINER GoCardless Engineering <engineering@gocardless.com>
+
+RUN set -x && \
+  apk --no-cache add nodejs mariadb-client bash build-base mariadb-dev tzdata curl && \
+  rm -rf /var/cache/apk/*
+
+WORKDIR /opt/postal
+
+# Installing Gems takes a long time, so only do it if the Gemfile has actually changed.
+COPY Gemfile /opt/postal
+COPY Gemfile.lock /opt/postal
+RUN set -x && \
+  bundle install --no-cache && \
+  rm -rf /usr/local/bundle/cache
+
+COPY . /opt/postal
+
+# Use the development env in order to load development assets, e.g. jquery
+RUN RAILS_ENV=development bundle exec rake assets:precompile
+
+RUN addgroup -g 1000 postal && \
+	adduser -G postal -u 1000 -D -H -h /opt/postal -s /bin/bash postal && \
+	chown -R postal:postal /opt/postal
+
+USER postal

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,7 +73,9 @@ class ApplicationController < ActionController::Base
   def append_info_to_payload(payload)
     super
     payload[:ip] = request.ip
-    payload[:user] = logged_in? ? current_user.id : nil
+    if ActiveRecord::Base.connected?
+      payload[:user] = logged_in? ? current_user.id : nil
+    end
   end
 
   def url_with_return_to(url)

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,0 +1,16 @@
+class HealthcheckController < ApplicationController
+
+  # set_browser_id comes from the Authie gem
+  skip_before_action :login_required, :set_browser_id
+
+  def index
+    if params[:probe] == "ready"
+      begin
+        Organization.count
+      rescue => e
+        render :plain => "Error: #{e}", :status => :internal_server_error and return
+      end
+    end
+    render :plain => "OK"
+  end
+end

--- a/app/models/outgoing_message_prototype.rb
+++ b/app/models/outgoing_message_prototype.rb
@@ -160,17 +160,15 @@ class OutgoingMessagePrototype
       mail.sender = @sender
       mail.subject = @subject
       mail.reply_to = @reply_to
-      if @html_body.blank? && attachments.empty?
-        mail.body = @plain_body
-      else
+      mail.part :content_type => "multipart/alternative" do |p|
         if !@plain_body.blank?
-          mail.text_part = Mail::Part.new
-          mail.text_part.body = @plain_body
+          p.text_part = Mail::Part.new
+          p.text_part.body = @plain_body
         end
         if !@html_body.blank?
-          mail.html_part = Mail::Part.new
-          mail.html_part.content_type = "text/html; charset=UTF-8"
-          mail.html_part.body = @html_body
+          p.html_part = Mail::Part.new
+          p.html_part.content_type = "text/html; charset=UTF-8"
+          p.html_part.body = @html_body
         end
       end
       attachments.each do |attachment|

--- a/app/models/track_domain.rb
+++ b/app/models/track_domain.rb
@@ -74,11 +74,15 @@ class TrackDomain < ApplicationRecord
   end
 
   def has_ssl?
-    ssl_certificate && ssl_certificate.active?
+    ssl_certificate && (use_external_ssl? || ssl_certificate.active?)
   end
 
   def use_ssl?
     ssl_enabled? && has_ssl?
+  end
+
+  def use_external_ssl?
+    Postal.config.general.use_external_ssl_for_tracking?
   end
 
   def ssl_certificate

--- a/bin/show-config
+++ b/bin/show-config
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require_relative "../lib/postal/config"
+
+Postal.check_config!
+puts Postal.config.to_yaml

--- a/config/fast_server.cert
+++ b/config/fast_server.cert
@@ -1,0 +1,1 @@
+<%= ENV["POSTAL_FAST_SERVER_CERT"] %>

--- a/config/fast_server.key
+++ b/config/fast_server.key
@@ -1,0 +1,1 @@
+<%= ENV["POSTAL_FAST_SERVER_KEY"] %>

--- a/config/lets_encrypt.pem
+++ b/config/lets_encrypt.pem
@@ -1,0 +1,1 @@
+<%= ENV["POSTAL_LETS_ENCRYPT_PEM"] %>

--- a/config/postal.defaults.yml
+++ b/config/postal.defaults.yml
@@ -13,6 +13,7 @@ general:
   exception_url:
   maximum_delivery_attempts: 18
   use_local_ns_for_domains: false
+  use_external_ssl_for_tracking: false
 
 web_server:
   bind_address: 127.0.0.1

--- a/config/postal.yml
+++ b/config/postal.yml
@@ -65,8 +65,14 @@ dns:
 smtp_server:
   port: <%= ENV["POSTAL_SMTP_SERVER_PORT"] %>
 
-# TODO: We may need this!
-# smtp_relays:
+<% if ENV["POSTAL_SMTP_RELAY_HOSTNAME"] %>
+smtp_relays:
+  - hostname: <%= ENV["POSTAL_SMTP_RELAY_HOSTNAME"] %>
+    port: <%= ENV["POSTAL_SMTP_RELAY_PORT"] %>
+    ssl_mode: <%= ENV["POSTAL_SMTP_RELAY_SSL_MODE"] %>
+    user: <%= ENV["POSTAL_SMTP_RELAY_USER"] %>
+    secret: <%= ENV["POSTAL_SMTP_RELAY_SECRET"] %>
+<% end %>
 
 smtp:
   # Specify an SMTP server that can be used to send messages from the Postal management

--- a/config/postal.yml
+++ b/config/postal.yml
@@ -1,0 +1,86 @@
+---
+web:
+  # The host that the management interface will be available on
+  host: <%= ENV["POSTAL_WEB_HOST"] %>
+  # The protocol that requests to the management interface should happen on
+  protocol: <%= ENV["POSTAL_WEB_PROTOCOL"] %>
+
+web_server:
+  bind_address: <%= ENV["POSTAL_WEB_SERVER_BIND_ADDRESS"] %>
+  port: <%= ENV["POSTAL_WEB_SERVER_PORT"] %>
+  max_threads: <%= ENV["POSTAL_WEB_SERVER_MAX_THREADS"] %>
+
+fast_server:
+  # This can be enabled to enable click & open tracking on emails. It is disabled by
+  # default as it requires a separate static IP address on your server.
+  enabled: <%= ENV["POSTAL_FAST_SERVER_ENABLED"] %>
+  bind_address: <%= ENV["POSTAL_FAST_SERVER_BIND_ADDRESS"] %>
+  port: <%= ENV["POSTAL_FAST_SERVER_PORT"] %>
+  ssl_port: <%= ENV["POSTAL_FAST_SERVER_SSL_PORT"] %>
+
+general:
+  # This can be changed to allow messages to be sent from multiple IP addresses
+  use_ip_pools: false
+  exception_url: <%= ENV["POSTAL_GENERAL_EXCEPTION_URL"] %>
+  # Always use local DNS resolver, rather than attempting to find a nameserver
+  # by stepping through domain parts, which seems to give us a result of
+  # `0.0.0.0`, which obviously doesn't work if you try to use it for
+  # resolution.
+  use_local_ns_for_domains: true
+
+main_db:
+  # Specify the connection details for your MySQL database
+  host: <%= ENV["MYSQL_HOST"] %>
+  username: <%= ENV["MYSQL_USER"] %>
+  password: <%= ENV["MYSQL_PASSWORD"] %>
+  database: <%= ENV["MYSQL_DATABASE_MAIN"] %>
+
+message_db:
+  # Specify the connection details for your MySQL server that will be house the
+  # message databases for mail servers.
+  host: <%= ENV["MYSQL_HOST"] %>
+  username: <%= ENV["MYSQL_USER"] %>
+  password: <%= ENV["MYSQL_PASSWORD"] %>
+  prefix: <%= ENV["MYSQL_DATABASE_MESSAGE_PREFIX"] %>
+
+rabbitmq:
+  # Specify the connection details for your RabbitMQ server.
+  host: <%= ENV["RABBITMQ_HOST"] %>
+  username: <%= ENV["RABBITMQ_USER"] %>
+  password: <%= ENV["RABBITMQ_PASSWORD"] %>
+  vhost: <%= ENV.fetch("RABBITMQ_VHOST", "/postal") %>
+
+dns:
+  # Specifies the DNS record that you have configured. Refer to the documentation at
+  # https://github.com/atech/postal/wiki/Domains-&-DNS-Configuration for further
+  # information about these.
+  mx_records:
+    - <%= ENV["POSTAL_DNS_MX_RECORD"] %> # mx.postal.example.com
+  smtp_server_hostname: <%= ENV["POSTAL_DNS_SMTP_SERVER_HOSTNAME"] %> # postal.example.com
+  spf_include: <%= ENV["POSTAL_DNS_SPF_INCLUDE"] %> # spf.postal.example.com
+  return_path: <%= ENV["POSTAL_DNS_RETURN_PATH"] %> # rp.postal.example.com
+  route_domain: <%= ENV["POSTAL_DNS_ROUTE_DOMAIN"] %> # routes.postal.example.com
+  track_domain: <%= ENV["POSTAL_DNS_TRACK_DOMAIN"] %> # track.postal.example.com
+
+smtp_server:
+  port: <%= ENV["POSTAL_SMTP_SERVER_PORT"] %>
+
+# TODO: We may need this!
+# smtp_relays:
+
+smtp:
+  # Specify an SMTP server that can be used to send messages from the Postal management
+  # system to users. You can configure this to use a Postal mail server once the
+  # your installation has been set up.
+  host: <%= ENV["POSTAL_SMTP_HOST"] %> # 127.0.0.1
+  port: <%= ENV["POSTAL_SMTP_PORT"] %> # 2525
+  username: <%= ENV["POSTAL_SMTP_USERNAME"] %> # Complete when Postal is running and you can
+  password: <%= ENV["POSTAL_SMTP_PASSWORD"] %> # generate the credentials within the interface.
+  from_name: <%= ENV["POSTAL_SMTP_FROM_NAME"] %> # Postal
+  from_address: <%= ENV["POSTAL_SMTP_FROM_ADDRESS"] %> # postal@yourdomain.com
+
+rails:
+  environment: <%= ENV["RAILS_ENV"] %>
+  # This is generated automatically by the config initialization. It should be a random
+  # string unique to your installation.
+  secret_key: <%= ENV["POSTAL_RAILS_SECRET_KEY"] %>

--- a/config/postal.yml
+++ b/config/postal.yml
@@ -27,6 +27,8 @@ general:
   # `0.0.0.0`, which obviously doesn't work if you try to use it for
   # resolution.
   use_local_ns_for_domains: true
+  # Disable Postal's self-management of SSL for tracking domains
+  use_external_ssl_for_tracking: <%= ENV["POSTAL_GENERAL_USE_EXTERNAL_SSL_FOR_TRACKING"] %>
 
 main_db:
   # Specify the connection details for your MySQL database

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,4 +91,6 @@ Rails.application.routes.draw do
   match 'login/reset/:token' => 'sessions#finish_password_reset', :via => [:get, :post]
   root 'organizations#index'
   get 'ip' => 'sessions#ip'
+
+  get 'health_check' => 'healthcheck#index'
 end

--- a/config/signing.key
+++ b/config/signing.key
@@ -1,0 +1,1 @@
+<%= ENV["POSTAL_SIGNING_KEY"] %>

--- a/config/smtp.cert
+++ b/config/smtp.cert
@@ -1,0 +1,1 @@
+<%= ENV["POSTAL_SMTP_CERT"] %>

--- a/config/smtp.key
+++ b/config/smtp.key
@@ -1,0 +1,1 @@
+<%= ENV["POSTAL_SMTP_KEY"] %>

--- a/lib/postal/fast_server/interface.rb
+++ b/lib/postal/fast_server/interface.rb
@@ -68,6 +68,21 @@ module Postal
           end
         end
 
+        if request.path == "/health_check"
+          probe = request.params['probe']
+          if probe == "ready"
+            begin
+              # Make a cheap DB call, which will fail if the connection is down
+              ::TrackCertificate.count
+              return [200, {}, ["OK"]]
+            rescue => e
+              return [500, {}, ["Error: #{e}"]]
+            end
+          else
+            return [200, {}, ["OK"]]
+          end
+        end
+
         if request.path =~ /\A\/([a-z0-9\-]+)\/([a-z0-9\-]+)/i
           server_token = $1
           link_token = $2

--- a/lib/postal/lets_encrypt.rb
+++ b/lib/postal/lets_encrypt.rb
@@ -8,7 +8,7 @@ module Postal
     end
 
     def self.private_key
-      @private_key ||= OpenSSL::PKey::RSA.new(File.open(Postal.lets_encrypt_private_key_path))
+      @private_key ||= OpenSSL::PKey::RSA.new(Postal.erb_read(Postal.lets_encrypt_private_key_path))
     end
 
     def self.endpoint

--- a/lib/postal/message_db/migrations/19_increase_links_url_size.rb
+++ b/lib/postal/message_db/migrations/19_increase_links_url_size.rb
@@ -1,0 +1,11 @@
+module Postal
+  module MessageDB
+    module Migrations
+      class IncreaseLinksUrlSize < Postal::MessageDB::Migration
+        def up
+          @database.query("ALTER TABLE `#{@database.database_name}`.`links` MODIFY `url` TEXT")
+        end
+      end
+    end
+  end
+end

--- a/lib/postal/smtp_sender.rb
+++ b/lib/postal/smtp_sender.rb
@@ -23,11 +23,17 @@ module Postal
           hostname = server[:hostname]
           port = server[:port] || 25
           ssl_mode = server[:ssl_mode] || 'Auto'
+          user = server[:user]
+          secret = server[:secret]
         else
           hostname = server
           port = 25
           ssl_mode = 'Auto'
         end
+
+        # Credentials are only defined for relay hosts
+        user ||= nil
+        secret ||= nil
 
         @hostnames << hostname
         [:aaaa, :a].each do |ip_type|
@@ -63,7 +69,10 @@ module Postal
             else
               # Nothing
             end
-            smtp_client.start(@source_ip_address ? @source_ip_address.hostname : self.class.default_helo_hostname)
+            smtp_client.start(
+              @source_ip_address ? @source_ip_address.hostname : self.class.default_helo_hostname,
+              user, secret
+            )
             log "Connected to #{@remote_ip}:#{port} (#{hostname})"
           rescue => e
             log "Cannot connect to #{@remote_ip}:#{port} (#{hostname}) (#{e.class}: #{e.message})"
@@ -262,7 +271,9 @@ module Postal
           {
             :hostname => relay.hostname,
             :port => relay.port,
-            :ssl_mode => relay.ssl_mode
+            :ssl_mode => relay.ssl_mode,
+            :user => relay.user,
+            :secret => relay.secret,
           }
         else
           nil


### PR DESCRIPTION
- Implement SynergiTech's production fixes
- Add Dockerfile, to build Postal in an Alpine environment
- Inject config via environment variables
- Support authentication for SMTP relays, so that we can send via SendGrid.
  Note that the disadvantage of this is that Postal won't receive bounces.
- Allow tracking domains to use non-Postal provisioned SSL certificates
- Add primitive healthcheck routes to the main and fast server, to support Kubernetes probes.